### PR TITLE
feat: add install and uninstall commands

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -217,6 +217,8 @@ dependencies = [
  "clap",
  "env_logger",
  "log",
+ "nix",
+ "tempfile",
  "trycmd",
  "tzf-rs",
  "zbus",
@@ -269,6 +271,12 @@ name = "cfg-if"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
+
+[[package]]
+name = "cfg_aliases"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f079e83a288787bcd14a6aea84cee5c87a67c5a3e660c30f557a3d24761b3527"
 
 [[package]]
 name = "clap"
@@ -672,6 +680,18 @@ name = "multimap"
 version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d87ecb2933e8aeadb3e3a02b828fed80a7528047e68b4f424523a0981a3a084"
+
+[[package]]
+name = "nix"
+version = "0.31.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cf20d2fde8ff38632c426f1165ed7436270b44f199fc55284c38276f9db47c3d"
+dependencies = [
+ "bitflags",
+ "cfg-if",
+ "cfg_aliases",
+ "libc",
+]
 
 [[package]]
 name = "normalize-line-endings"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,6 +10,8 @@ keywords = ["dbus", "geoclue", "systemd", "timezone", "zoneinfo"]
 [dependencies]
 env_logger = { version = "=0.11.11", default-features = false }
 log = { version = "=0.4.33", default-features = false }
+nix = { version = "0.31.3", default-features = false, features = ["user"] }
+tempfile = "3.27.0"
 tzf-rs = { version = "=1.3.7", default-features = false, features = ["bundled"] }
 zvariant = { version = "=5.13.1", default-features = false }
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ keywords = ["dbus", "geoclue", "systemd", "timezone", "zoneinfo"]
 env_logger = { version = "=0.11.11", default-features = false }
 log = { version = "=0.4.33", default-features = false }
 nix = { version = "0.31.3", default-features = false, features = ["user"] }
-tempfile = "3.27.0"
+tempfile = { version= "3.27.0", default-features = false }
 tzf-rs = { version = "=1.3.7", default-features = false, features = ["bundled"] }
 zvariant = { version = "=5.13.1", default-features = false }
 

--- a/README.md
+++ b/README.md
@@ -35,6 +35,8 @@ Usage: automatic-timezoned [OPTIONS]
 
 Options:
   -l, --log-level <LOG_LEVEL>  Log level filter. See <https://docs.rs/env_logger> for syntax [env: AUTOTZD_LOG_LEVEL=] [default: info]
+      --install                Install Automatic Timezoned as a system service
+      --uninstall              Uninstall Automatic Timezoned
   -h, --help                   Print help
   -V, --version                Print version
 

--- a/src/installer.rs
+++ b/src/installer.rs
@@ -1,0 +1,336 @@
+use std::{
+    error::Error, fs, io::Write, os::unix::fs::PermissionsExt, path::Path, process::Command,
+};
+
+// Note: this is written to disk only for the purpose of uninstallation, so this just lists all files (and folders) that are likely installed (aka all the path that should be deleted when uninstalled). The first line denotes the manifest version, if future versions require more sophisticated uninstalls then this is how that will be detected
+static INSTALLATION_MANIFEST: &str = r#"version: 1
+/usr/bin/automatic-timezoned
+/etc/geoclue/conf.d/automatic-timezoned.conf
+/etc/polkit-1/rules.d/automatic-timezoned.rules
+/etc/systemd/system/automatic-timezoned.service
+/var/lib/automatic-timezoned/installation_manifest.txt
+/var/lib/automatic-timezoned
+"#;
+
+static GEOCLUE_CONF_FILE: &str = r#"; vim: ft=dosini
+[automatic-timezoned]
+allowed=true
+system=true
+users={}
+"#;
+
+static POLKIT_CONF_FILE: &str = r#"// vim: ft=javascript
+polkit.addRule(function(action, subject) {
+  if (action.id == "org.freedesktop.timedate1.set-timezone" && subject.user == "{}") {
+	return polkit.Result.YES;
+  }
+});
+"#;
+
+static SYSTEMD_SERVICE_FILE: &str = r#"# vim: ft=systemd
+[Unit]
+Description=Automatically update system timezone based on location
+
+[Service]
+User={}
+ExecStart=/usr/bin/automatic-timezoned
+Restart=on-failure
+RestartSec=300
+
+[Install]
+WantedBy=multi-user.target
+"#;
+
+fn read_stdin() -> Result<String, Box<dyn Error>> {
+    let mut output = String::new();
+    std::io::stdout().flush()?;
+    std::io::stdin().read_line(&mut output)?;
+    Ok(output.trim().to_string())
+}
+
+fn get_stdin_yes_no() -> Result<bool, Box<dyn Error>> {
+    loop {
+        match read_stdin()?.as_str() {
+            "Y" | "y" | "" => return Ok(true),
+            "N" | "n" => return Ok(false),
+            _ => print!("Please enter 'y' or 'n' "),
+        }
+    }
+}
+
+fn format_template(template: &str, args: &[&str]) -> String {
+    let mut output = String::with_capacity(template.len());
+    let mut parts = template.split("{}");
+
+    output.push_str(parts.next().unwrap());
+
+    let parts = parts.collect::<Vec<_>>();
+    debug_assert_eq!(args.len(), parts.len());
+    for (arg, part) in args.iter().zip(parts) {
+        output.push_str(arg);
+        output.push_str(part);
+    }
+
+    output
+}
+
+fn run_cmd(cmd: &str, args: &[&str]) -> Result<(), Box<dyn Error>> {
+    let status = Command::new(cmd).args(args).status()?;
+    if !status.success() {
+        return Err(Box::new(std::io::Error::other(format!(
+            "Failed to execute command {cmd} {args:?}, error code {:?}",
+            status.code()
+        ))));
+    }
+    Ok(())
+}
+
+fn safe_write(path: impl AsRef<Path>, contents: impl AsRef<[u8]>) -> Result<(), Box<dyn Error>> {
+    let (path, contents) = (path.as_ref(), contents.as_ref());
+    let output_folder = path.parent().ok_or_else(|| {
+        Box::new(std::io::Error::other(format!(
+            "Failed to write file, output path has no parent. Failed path: {path:?}"
+        )))
+    })?;
+    fs::create_dir_all(output_folder)?;
+    let mut temp_file = tempfile::NamedTempFile::new_in(output_folder)?;
+    temp_file.write_all(contents)?;
+    temp_file.persist(path)?;
+    Ok(())
+}
+
+pub fn install() -> Result<(), Box<dyn Error>> {
+    // step 1: test if this is root
+    if !nix::unistd::geteuid().is_root() {
+        println!(
+            "This must be run as root, please rerun with `sudo ./automatic-timezoned --install`"
+        );
+        return Ok(());
+    }
+
+    println!("Installing Automatic Timezoned");
+    println!("Warning: this installer is still experimental and you might still need to manually configure your system after installation");
+
+    // step 2: get user name and uid
+    let uid = std::env::var("SUDO_UID")?;
+    let uid: u32 = uid.parse()?;
+    println!("Detected user uid is {uid}");
+    let user_name = std::env::var("SUDO_USER")?;
+    println!("Detected user name is {user_name}");
+
+    // step 3: write installation manifest
+    fs::create_dir_all("/var/lib/automatic-timezoned")?;
+    fs::write(
+        "/var/lib/automatic-timezoned/installation_manifest.txt",
+        INSTALLATION_MANIFEST,
+    )?;
+    println!("Wrote installation manifest");
+
+    let mut did_all_install = true;
+
+    // step 4: copy binary
+    print!("Install (copy) binary to `/usr/bin/automatic-timezoned`? Y/n ");
+    if get_stdin_yes_no()? {
+        fs::create_dir_all("/usr/bin")?;
+        fs::copy(std::env::current_exe()?, "/usr/bin/automatic-timezoned")?;
+        fs::set_permissions(
+            "/usr/bin/automatic-timezoned",
+            fs::Permissions::from_mode(0o755),
+        )?;
+    } else {
+        println!("Skipped installing binary");
+        did_all_install = false;
+    }
+
+    // step 5: write geoclue config file
+    print!("Install geoclue config file to `/etc/geoclue/conf.d/automatic-timezoned.conf`? Y/n ");
+    if get_stdin_yes_no()? {
+        let geoclue_conf_file = format_template(GEOCLUE_CONF_FILE, &[uid.to_string().as_str()]);
+        safe_write(
+            "/etc/geoclue/conf.d/automatic-timezoned.conf",
+            geoclue_conf_file,
+        )?;
+        fs::set_permissions(
+            "/etc/geoclue/conf.d/automatic-timezoned.conf",
+            fs::Permissions::from_mode(0o644),
+        )?;
+    } else {
+        println!("Skipped installing geoclue config file");
+        did_all_install = false;
+    }
+
+    // step 6: write polkit config file
+    print!("Install polkit config file to `/etc/polkit-1/rules.d/automatic-timezoned.rules`? Y/n ");
+    if get_stdin_yes_no()? {
+        let polkit_conf_file = format_template(POLKIT_CONF_FILE, &[user_name.as_str()]);
+        safe_write(
+            "/etc/polkit-1/rules.d/automatic-timezoned.rules",
+            polkit_conf_file,
+        )?;
+        fs::set_permissions(
+            "/etc/polkit-1/rules.d/automatic-timezoned.rules",
+            fs::Permissions::from_mode(0o644),
+        )?;
+    } else {
+        println!("Skipped installing polkit config file");
+        did_all_install = false;
+    }
+
+    // step 7: write systemd service file
+    print!(
+        "Install systemd service file to `/etc/systemd/system/automatic-timezoned.service`? Y/n "
+    );
+    if get_stdin_yes_no()? {
+        let systemd_service_file = format_template(SYSTEMD_SERVICE_FILE, &[user_name.as_str()]);
+        safe_write(
+            "/etc/systemd/system/automatic-timezoned.service",
+            systemd_service_file,
+        )?;
+        fs::set_permissions(
+            "/etc/systemd/system/automatic-timezoned.service",
+            fs::Permissions::from_mode(0o644),
+        )?;
+    } else {
+        println!("Skipped installing systemd service file");
+        did_all_install = false;
+    }
+
+    // step 7: run `systemctl daemon-reload`
+    run_cmd("systemctl", &["daemon-reload"])?;
+    println!("Ran `systemctl daemon-reload`");
+
+    // step 8: enable systemd service
+    if did_all_install {
+        print!("Start systemd service? Y/n ");
+        if get_stdin_yes_no()? {
+            run_cmd(
+                "systemctl",
+                &["enable", "--now", "automatic-timezoned.service"],
+            )?;
+        } else {
+            println!("Skipped starting systemd service");
+            did_all_install = false;
+        }
+    } else {
+        println!("Because some install options were skipped, the service will not be started");
+    }
+
+    // step 9: check systemd service
+    println!("Checking systemd service status:");
+    // not using run_cmd() here because a failure here shouldn't stop the program
+    let status = Command::new("systemctl")
+        .args(["--no-pager", "status", "automatic-timezoned.service"])
+        .status()?;
+    if !status.success() {
+        println!(
+            "Warning: systemctl status failed with exit code {:?}",
+            status.code()
+        );
+    }
+
+    println!("Finished installation, please check systemd status above.");
+    if !did_all_install {
+        println!("Warning: some installation were skipped and the program may not be fully installed, if you want to reinstall this then please first run `sudo ./automatic-timezoned --uninstall`");
+    }
+
+    Ok(())
+}
+
+pub fn uninstall() -> Result<(), Box<dyn Error>> {
+    // step 1: test if this is root
+    if !nix::unistd::geteuid().is_root() {
+        println!(
+            "This must be run as root, please rerun with `sudo ./automatic-timezoned --uninstall`"
+        );
+        return Ok(());
+    }
+
+    // step 2: get manifest and run appropriate installer
+    if !fs::exists("/var/lib/automatic-timezoned/installation_manifest.txt")? {
+        eprintln!("Fatal: could not find the essential installation manifest file, so the program cannot be uninstalled.");
+        return Ok(());
+    }
+
+    let manifest = fs::read_to_string("/var/lib/automatic-timezoned/installation_manifest.txt")?;
+    let version = match manifest.lines().next() {
+        Some(v) => v,
+        None => {
+            return Err(Box::new(std::io::Error::other(
+                "Cannot uninstall because installation manifest appears to be empty",
+            )))
+        }
+    };
+    let version = match version.strip_prefix("version: ") {
+		Some(v) => v,
+		None => return Err(Box::new(std::io::Error::other("Cannot uninstall because installation manifest is malformed, must start with \"version: {}\""))),
+	};
+
+    match version {
+        "1" => uninstall_v1(manifest)?,
+        _ => {
+            return Err(Box::new(std::io::Error::other(
+                "Cannot uninstall because the installation manifest version is unknown",
+            )))
+        }
+    }
+
+    println!("Uninstallation is complete");
+
+    Ok(())
+}
+
+fn uninstall_v1(manifest: String) -> Result<(), Box<dyn Error>> {
+    // step 1: remove systemd service
+    println!("Disabling systemd service...");
+    let result = run_cmd(
+        "systemctl",
+        &["disable", "--now", "automatic-timezoned.service"],
+    );
+    if let Err(err) = result {
+        eprintln!("WARNING: Failed to disable systemd service: {err}");
+    }
+
+    // step 2: remove all files and folders listed in installation manifest
+    let installed_files = manifest
+        .lines()
+        .skip(1)
+        .filter(|line| !line.is_empty())
+        .collect::<Vec<_>>();
+
+    let mut skipped_files = vec![];
+    for path in installed_files {
+        if !fs::exists(path)? {
+            eprintln!("WARNING: could not find the file \"{path}\" and it will not be automatically removed (the user might have installed it somewhere else?)");
+            skipped_files.push(path);
+            continue;
+        }
+        let is_dir = Path::new(path).is_dir();
+        print!(
+            "Remove {} \"{path}\"? Y/n ",
+            if is_dir { "folder" } else { "file" }
+        );
+        if get_stdin_yes_no()? {
+            if is_dir {
+                fs::remove_dir(path)?;
+            } else {
+                fs::remove_file(path)?;
+            }
+        } else {
+            skipped_files.push(path);
+        }
+    }
+
+    // step 3: run `systemctl daemon-reload`
+    run_cmd("systemctl", &["daemon-reload"])?;
+    println!("Ran `systemctl daemon-reload`");
+
+    // final warnings
+    if !skipped_files.is_empty() {
+        eprintln!("Warning: these files were skipped during uninstallation and could still be on your computer:");
+        for path in skipped_files {
+            eprintln!("{path}");
+        }
+    }
+
+    Ok(())
+}

--- a/src/installer.rs
+++ b/src/installer.rs
@@ -85,6 +85,7 @@ fn run_cmd(cmd: &str, args: &[&str]) -> Result<(), Box<dyn Error>> {
     Ok(())
 }
 
+// Prevents half-written files by writing temp files and only moving them once fully written
 fn safe_write(path: impl AsRef<Path>, contents: impl AsRef<[u8]>) -> Result<(), Box<dyn Error>> {
     let (path, contents) = (path.as_ref(), contents.as_ref());
     let output_folder = path.parent().ok_or_else(|| {
@@ -100,25 +101,31 @@ fn safe_write(path: impl AsRef<Path>, contents: impl AsRef<[u8]>) -> Result<(), 
 }
 
 pub fn install() -> Result<(), Box<dyn Error>> {
-    // step 1: test if this is root
+    // first: test if this is root
     if !nix::unistd::geteuid().is_root() {
         println!(
             "This must be run as root, please rerun with `sudo ./automatic-timezoned --install`"
         );
         return Ok(());
     }
+	
+	// next: check if already installed
+	if fs::exists("/var/lib/automatic-timezoned/installation_manifest.txt")? {
+		eprintln!("This program is already installed, please run `sudo ./automatic-timezoned --uninstall` before reinstalling");
+		return Ok(());
+	}
 
     println!("Installing Automatic Timezoned");
     println!("Warning: this installer is still experimental and you might still need to manually configure your system after installation");
 
-    // step 2: get user name and uid
+    // next: get user name and uid
     let uid = std::env::var("SUDO_UID")?;
     let uid: u32 = uid.parse()?;
     println!("Detected user uid is {uid}");
     let user_name = std::env::var("SUDO_USER")?;
     println!("Detected user name is {user_name}");
 
-    // step 3: write installation manifest
+    // next: write installation manifest
     fs::create_dir_all("/var/lib/automatic-timezoned")?;
     fs::write(
         "/var/lib/automatic-timezoned/installation_manifest.txt",
@@ -128,7 +135,7 @@ pub fn install() -> Result<(), Box<dyn Error>> {
 
     let mut did_all_install = true;
 
-    // step 4: copy binary
+    // next: copy binary
     print!("Install (copy) binary to `/usr/bin/automatic-timezoned`? Y/n ");
     if get_stdin_yes_no()? {
         fs::create_dir_all("/usr/bin")?;
@@ -142,7 +149,7 @@ pub fn install() -> Result<(), Box<dyn Error>> {
         did_all_install = false;
     }
 
-    // step 5: write geoclue config file
+    // next: write geoclue config file
     print!("Install geoclue config file to `/etc/geoclue/conf.d/automatic-timezoned.conf`? Y/n ");
     if get_stdin_yes_no()? {
         let geoclue_conf_file = format_template(GEOCLUE_CONF_FILE, &[uid.to_string().as_str()]);
@@ -159,7 +166,7 @@ pub fn install() -> Result<(), Box<dyn Error>> {
         did_all_install = false;
     }
 
-    // step 6: write polkit config file
+    // next: write polkit config file
     print!("Install polkit config file to `/etc/polkit-1/rules.d/automatic-timezoned.rules`? Y/n ");
     if get_stdin_yes_no()? {
         let polkit_conf_file = format_template(POLKIT_CONF_FILE, &[user_name.as_str()]);
@@ -176,7 +183,7 @@ pub fn install() -> Result<(), Box<dyn Error>> {
         did_all_install = false;
     }
 
-    // step 7: write systemd service file
+    // next: write systemd service file
     print!(
         "Install systemd service file to `/etc/systemd/system/automatic-timezoned.service`? Y/n "
     );
@@ -195,11 +202,11 @@ pub fn install() -> Result<(), Box<dyn Error>> {
         did_all_install = false;
     }
 
-    // step 7: run `systemctl daemon-reload`
+    // next: run `systemctl daemon-reload`
     run_cmd("systemctl", &["daemon-reload"])?;
     println!("Ran `systemctl daemon-reload`");
 
-    // step 8: enable systemd service
+    // next: enable systemd service
     if did_all_install {
         print!("Start systemd service? Y/n ");
         if get_stdin_yes_no()? {
@@ -215,7 +222,7 @@ pub fn install() -> Result<(), Box<dyn Error>> {
         println!("Because some install options were skipped, the service will not be started");
     }
 
-    // step 9: check systemd service
+    // next: check systemd service
     println!("Checking systemd service status:");
     // not using run_cmd() here because a failure here shouldn't stop the program
     let status = Command::new("systemctl")
@@ -237,7 +244,7 @@ pub fn install() -> Result<(), Box<dyn Error>> {
 }
 
 pub fn uninstall() -> Result<(), Box<dyn Error>> {
-    // step 1: test if this is root
+    // first: test if this is root
     if !nix::unistd::geteuid().is_root() {
         println!(
             "This must be run as root, please rerun with `sudo ./automatic-timezoned --uninstall`"
@@ -245,7 +252,7 @@ pub fn uninstall() -> Result<(), Box<dyn Error>> {
         return Ok(());
     }
 
-    // step 2: get manifest and run appropriate installer
+    // next: get manifest
     if !fs::exists("/var/lib/automatic-timezoned/installation_manifest.txt")? {
         eprintln!("Fatal: could not find the essential installation manifest file, so the program cannot be uninstalled.");
         return Ok(());
@@ -260,6 +267,8 @@ pub fn uninstall() -> Result<(), Box<dyn Error>> {
             )))
         }
     };
+	
+	// next: get manifest version and run appropriate uninstaller
     let version = match version.strip_prefix("version: ") {
 		Some(v) => v,
 		None => return Err(Box::new(std::io::Error::other("Cannot uninstall because installation manifest is malformed, must start with \"version: {}\""))),
@@ -280,7 +289,7 @@ pub fn uninstall() -> Result<(), Box<dyn Error>> {
 }
 
 fn uninstall_v1(manifest: String) -> Result<(), Box<dyn Error>> {
-    // step 1: remove systemd service
+    // next: remove systemd service
     println!("Disabling systemd service...");
     let result = run_cmd(
         "systemctl",
@@ -290,7 +299,7 @@ fn uninstall_v1(manifest: String) -> Result<(), Box<dyn Error>> {
         eprintln!("WARNING: Failed to disable systemd service: {err}");
     }
 
-    // step 2: remove all files and folders listed in installation manifest
+    // next: remove all files and folders listed in installation manifest
     let installed_files = manifest
         .lines()
         .skip(1)
@@ -320,11 +329,11 @@ fn uninstall_v1(manifest: String) -> Result<(), Box<dyn Error>> {
         }
     }
 
-    // step 3: run `systemctl daemon-reload`
+    // next: run `systemctl daemon-reload`
     run_cmd("systemctl", &["daemon-reload"])?;
     println!("Ran `systemctl daemon-reload`");
 
-    // final warnings
+    // next: give final warnings
     if !skipped_files.is_empty() {
         eprintln!("Warning: these files were skipped during uninstallation and could still be on your computer:");
         for path in skipped_files {

--- a/src/installer.rs
+++ b/src/installer.rs
@@ -2,7 +2,7 @@ use std::{
     error::Error, fs, io::Write, os::unix::fs::PermissionsExt, path::Path, process::Command,
 };
 
-// Note: this is written to disk only for the purpose of uninstallation, so this just lists all files (and folders) that are likely installed (aka all the path that should be deleted when uninstalled). The first line denotes the manifest version, if future versions require more sophisticated uninstalls then this is how that will be detected
+// Note: this is written to disk only for the purpose of uninstallation, so this just lists all files (and folders) that are likely installed (aka all the paths that should be deleted when uninstalled). The first line denotes the manifest version, if future versions require more sophisticated uninstalls then this is how that will be detected
 static INSTALLATION_MANIFEST: &str = r#"version: 1
 /usr/bin/automatic-timezoned
 /etc/geoclue/conf.d/automatic-timezoned.conf
@@ -74,6 +74,7 @@ fn format_template(template: &str, args: &[&str]) -> String {
     output
 }
 
+// note: this does not capture the output of run commands
 fn run_cmd(cmd: &str, args: &[&str]) -> Result<(), Box<dyn Error>> {
     let status = Command::new(cmd).args(args).status()?;
     if !status.success() {
@@ -85,7 +86,7 @@ fn run_cmd(cmd: &str, args: &[&str]) -> Result<(), Box<dyn Error>> {
     Ok(())
 }
 
-// Prevents half-written files by writing temp files and only moving them once fully written
+// prevents half-written files by writing temp files and only moving them once fully written
 fn safe_write(path: impl AsRef<Path>, contents: impl AsRef<[u8]>) -> Result<(), Box<dyn Error>> {
     let (path, contents) = (path.as_ref(), contents.as_ref());
     let output_folder = path.parent().ok_or_else(|| {
@@ -108,12 +109,12 @@ pub fn install() -> Result<(), Box<dyn Error>> {
         );
         return Ok(());
     }
-	
-	// next: check if already installed
-	if fs::exists("/var/lib/automatic-timezoned/installation_manifest.txt")? {
-		eprintln!("This program is already installed, please run `sudo ./automatic-timezoned --uninstall` before reinstalling");
-		return Ok(());
-	}
+
+    // next: check if already installed
+    if fs::exists("/var/lib/automatic-timezoned/installation_manifest.txt")? {
+        eprintln!("This program is already installed, please run `sudo ./automatic-timezoned --uninstall` before reinstalling");
+        return Ok(());
+    }
 
     println!("Installing Automatic Timezoned");
     println!("Warning: this installer is still experimental and you might still need to manually configure your system after installation");
@@ -124,6 +125,22 @@ pub fn install() -> Result<(), Box<dyn Error>> {
     println!("Detected user uid is {uid}");
     let user_name = std::env::var("SUDO_USER")?;
     println!("Detected user name is {user_name}");
+
+    // next: test if the chosen user can contact geoclue
+    println!("Attempting to contact geoclue... (if this hangs, the installation will not work with your current user)");
+    Command::new("sudo")
+        .args(&[
+            "-u",
+            &*user_name,
+            "busctl",
+            "--system",
+            "call",
+            "org.freedesktop.GeoClue2",
+            "/org/freedesktop/GeoClue2/Manager",
+            "org.freedesktop.GeoClue2.Manager",
+            "GetClient",
+        ])
+        .status()?;
 
     // next: write installation manifest
     fs::create_dir_all("/var/lib/automatic-timezoned")?;
@@ -267,8 +284,8 @@ pub fn uninstall() -> Result<(), Box<dyn Error>> {
             )))
         }
     };
-	
-	// next: get manifest version and run appropriate uninstaller
+
+    // next: get manifest version and run appropriate uninstaller
     let version = match version.strip_prefix("version: ") {
 		Some(v) => v,
 		None => return Err(Box::new(std::io::Error::other("Cannot uninstall because installation manifest is malformed, must start with \"version: {}\""))),

--- a/src/main.rs
+++ b/src/main.rs
@@ -63,9 +63,9 @@ fn main() -> Result<(), Box<dyn Error>> {
     let conn = Connection::system()?;
 
     let gclue_manager = geoclue::ManagerProxyBlocking::new(&conn)?;
-	info!("Acquiring manager from geoclue (this should be instant)");
+    info!("Acquiring manager from geoclue (this should be instant)");
     let gclue_client = gclue_manager.get_client()?;
-	info!("Acquired manager from geoclue");
+    info!("Acquired manager from geoclue");
     gclue_client.set_desktop_id("automatic-timezoned")?;
     gclue_client.set_distance_threshold(10000)?; // meters
     gclue_client.set_requested_accuracy_level(geoclue::AccuracyLevel::City as u32)?;

--- a/src/main.rs
+++ b/src/main.rs
@@ -63,7 +63,9 @@ fn main() -> Result<(), Box<dyn Error>> {
     let conn = Connection::system()?;
 
     let gclue_manager = geoclue::ManagerProxyBlocking::new(&conn)?;
+	info!("Acquiring manager from geoclue (this should be instant)");
     let gclue_client = gclue_manager.get_client()?;
+	info!("Acquired manager from geoclue");
     gclue_client.set_desktop_id("automatic-timezoned")?;
     gclue_client.set_distance_threshold(10000)?; // meters
     gclue_client.set_requested_accuracy_level(geoclue::AccuracyLevel::City as u32)?;

--- a/src/main.rs
+++ b/src/main.rs
@@ -8,6 +8,7 @@ use tzf_rs::DefaultFinder;
 use zbus::{blocking::Connection, proxy};
 
 mod geoclue;
+mod installer;
 
 /// Automatically update system timezone based on location
 #[derive(Parser)]
@@ -16,6 +17,12 @@ struct Args {
     /// Log level filter. See <https://docs.rs/env_logger> for syntax
     #[arg(short, long, default_value = "info", env = "AUTOTZD_LOG_LEVEL")]
     log_level: String,
+    /// Install Automatic Timezoned as a system service
+    #[arg(long)]
+    install: bool,
+    /// Uninstall Automatic Timezoned
+    #[arg(long)]
+    uninstall: bool,
 }
 
 #[proxy(
@@ -34,6 +41,16 @@ fn main() -> Result<(), Box<dyn Error>> {
     env_logger::Builder::new()
         .parse_filters(&args.log_level)
         .init();
+
+    if args.uninstall {
+        installer::uninstall()?;
+        return Ok(());
+    }
+
+    if args.install {
+        installer::install()?;
+        return Ok(());
+    }
 
     info!(
         "Starting {} {}...",

--- a/src/main.rs
+++ b/src/main.rs
@@ -18,10 +18,10 @@ struct Args {
     #[arg(short, long, default_value = "info", env = "AUTOTZD_LOG_LEVEL")]
     log_level: String,
     /// Install Automatic Timezoned as a system service
-    #[arg(long)]
+    #[arg(long, conflicts_with = "uninstall")]
     install: bool,
     /// Uninstall Automatic Timezoned
-    #[arg(long)]
+    #[arg(long, conflicts_with = "install")]
     uninstall: bool,
 }
 

--- a/tests/cmd/help.md
+++ b/tests/cmd/help.md
@@ -10,6 +10,8 @@ Usage: automatic-timezoned [OPTIONS]
 
 Options:
   -l, --log-level <LOG_LEVEL>  Log level filter. See <https://docs.rs/env_logger> for syntax [env: AUTOTZD_LOG_LEVEL=] [default: info]
+      --install                Install Automatic Timezoned as a system service
+      --uninstall              Uninstall Automatic Timezoned
   -h, --help                   Print help
   -V, --version                Print version
 
@@ -25,6 +27,8 @@ Usage: automatic-timezoned [OPTIONS]
 
 Options:
   -l, --log-level <LOG_LEVEL>  Log level filter. See <https://docs.rs/env_logger> for syntax [env: AUTOTZD_LOG_LEVEL=] [default: info]
+      --install                Install Automatic Timezoned as a system service
+      --uninstall              Uninstall Automatic Timezoned
   -h, --help                   Print help
   -V, --version                Print version
 


### PR DESCRIPTION
Background: I'm not super familiar with manually installing programs, and I'd be much more comfortable if there's a deterministic and easily documentable process for this. So, I've added commands to the program that automatically install or uninstall it. Almost all the code is hand-written, but the installation steps came almost entirely from chatgpt, so if I missed something or made part of it wrong then please let me know.

Some things to note:
- I edited to the systemd service file by removing the 'Requires' and 'after' fields since dbus automatically starts geoclue and it does not need to be running when automatic-timezoned starts.
- I also changed the 'WantedBy' field from 'default.target' to 'multi-user.target' because cahtgpt said that's better for long-running system services.
- I made the systemd service auto-restart after 5 minutes if it fails, but I'm not sure if that's a good wait time.
- This sets up the service to run automatic-timezoned using the same user that invokes `sudo ./automatic-timezoned --install`, it would be nice to have a custom user specifically for running this service, but I haven't found any way to get that to work (the GetManager call to geoclue hangs whenever I call it from any user other than my main desktop user).
- This also adds some logging to the GetManager call so that it's easier to identify cases where this is the failure point.

I'm very open to suggestions and fixes, I've never made a semi-official installer before so I wouldn't be surprised if there are big things to change, but still I've done my best to make sure everything is well made.